### PR TITLE
Add basic testing and documentation

### DIFF
--- a/replicated_kv_store/README.md
+++ b/replicated_kv_store/README.md
@@ -1,11 +1,33 @@
 # Replicated Key Value Store using Raft Consensus
 
-### How to Run
+### How to Run:
 
-- Clone the repo
+- Clone the repo.
 
-- Run multiple terminals (one for each replica)
+- Run multiple terminals (one for each replica).
 
-- Change directory to this folder (replicated_kv_store) in each terminal window
+- Change directory to this folder (replicated_kv_store) in each terminal window.
 
-- On each terminal, run ```go run . -n <number_of_replicas>``` and follow the on screen instructions
+- On each terminal, run ```go run . -n <number_of_replicas>``` and follow the on screen instructions.
+
+- For running tests, use ```go test```.
+
+### Instructions for writing new test cases:
+
+- A **test file** is a single file with a collection of **test cases**.
+
+- The test file should be named with a desired filename followed by `_test.go`, like `yourfilename_test.go`.
+
+- Each test case is a function with its name beginning with the word `Test` followed by a word or a phrase that starts with a capital letter. For example `TestRequestVote` and `TestRaft` are valid test case names while `Testrequestvote`, `TestrequestVote` and `Testraft` are invalid test case names.
+
+- The first and only parameter for every test case function is `t *testing.T`.
+
+- For handling failure conditions, call `t.Error()` or `t.Fail()`. These are similar to `fmt.Print()`. Use `fmt.Errorf()` if you want formatting similar to `fmt.Printf()`.
+
+- `t.Log()` can be used to provide debug information.
+
+- Check the test case written in the file `raft_node_test.go` for reference.
+
+- For keeping tests organized, it is preferable to have one test file per source file. For example, all the tests related to the functions in `raft_node.go` should be written in the test file `raft_node_test.go`.
+
+- Please write proper documentation for the tests, describing what feature it tests and how it manages to do so. This can be written in a comment block before the corresponding test case function.

--- a/replicated_kv_store/kv_store_node.go
+++ b/replicated_kv_store/kv_store_node.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"time"
+	"testing"
 
 	"github.com/krithikvaidya/distributed-dns/replicated_kv_store/protos"
 	"google.golang.org/grpc"
@@ -16,6 +17,14 @@ import (
 var n_replica int
 
 func init() {
+
+	/* 
+	 * Workaround for a Go bug
+	 * The Init() function for the testing package should be called
+	 * before our init() function for parsing the command-line arguments
+	 * of the `go test` command
+	 */
+	testing.Init()
 
 	// Command line parameters
 	flag.IntVar(&n_replica, "n", 5, "total number of replicas (default=5)")
@@ -28,7 +37,7 @@ func init() {
 
 func main() {
 
-	fmt.Println("\nRaft-based Replicated Key Value Store\n")
+	fmt.Println("\nRaft-based Replicated Key Value Store")
 
 	fmt.Printf("Enter the replica's id: ")
 	var rid int32

--- a/replicated_kv_store/raft_node_test.go
+++ b/replicated_kv_store/raft_node_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"testing"
+	"fmt"
+	"bytes"
+)
+
+/*
+ * This test is for the function InitializeNode() in `raft_node.go`
+ *
+ * Here, we call `InitializeNode()` and check whether each value in
+ * the `RaftNode` struct obtained from the function has the expected
+ * value and the type.
+ */
+func TestInitializeNode(t *testing.T) {
+	/*
+	 * Arbitrarily chosen values for number of replicas and
+	 * the replica ID
+	 */
+	var no_of_replicas, replica_id int32
+	no_of_replicas = 5
+	replica_id = 1
+	node := InitializeNode(no_of_replicas, replica_id)
+
+	// Here, we check every member of the RaftNode struct
+
+	// Check n_replicas
+	if node.n_replicas != no_of_replicas {
+		t.Errorf("Invalid value for n_replicas, expected %v", no_of_replicas)
+	}
+
+	// Check the type of `ready_chan`
+	var buf1 bytes.Buffer
+	fmt.Fprintf(&buf1, "%T", node.ready_chan)
+	ready_chan_type := buf1.String()
+
+	if ready_chan_type != "chan bool" {
+		t.Errorf("Invalid type %v for ready_chan, expected %v", ready_chan_type, "chan_bool")
+	}
+
+	// Check the value of `replicas_ready`
+	if node.replicas_ready != 0 {
+		t.Errorf("Invalid value %v for replicas_ready, expected 0", node.replicas_ready)
+	}
+
+	// Check the value of `replica_id`
+	if node.replica_id != replica_id {
+		t.Errorf("Invalid value for replica_id, expected %v", replica_id)
+	}
+
+	// Check the type of `peer_replica_clients`
+	var buf2 bytes.Buffer
+	fmt.Fprintf(&buf2, "%T", node.peer_replica_clients)
+	peer_replica_clients_type := buf2.String()
+
+	if peer_replica_clients_type != "[]protos.ConsensusServiceClient" {
+		t.Errorf("Invalid type %v for peer_replica_clients, expected %v", peer_replica_clients_type, "[]protos.ConsensusServiceClient")
+	}
+
+	// Check the value of `state`
+	if node.state != Follower {
+		t.Errorf("Invalid value %v for state, expected %v", node.state, "Follower")
+	}
+
+	// Check the value of `currentTerm`
+	if node.currentTerm != 0 {
+		t.Errorf("Invalid value %v for currentTerm, expected 0", node.currentTerm)
+	}
+
+	// Check the value of `votedFor`
+	if node.votedFor != -1 {
+		t.Errorf("Invalid value %v for votedFor, expected -1", node.votedFor)
+	}
+
+	// Check the type of `stopElectiontimer`
+	var buf3 bytes.Buffer
+	fmt.Fprintf(&buf3, "%T", node.stopElectiontimer)
+	stopElectiontimer_type := buf3.String()
+
+	if stopElectiontimer_type != "chan bool" {
+		t.Errorf("Invalid type %v for stopElectiontimer, expected %v", stopElectiontimer_type, "chan bool")
+	}
+
+	// Check the type of `electionResetEvent`
+	var buf4 bytes.Buffer
+	fmt.Fprintf(&buf4, "%T", node.electionResetEvent)
+	electionResetEvent_type := buf4.String()
+
+	if electionResetEvent_type != "chan bool" {
+		t.Errorf("Invalid type %v for electionResetEvent, expected %v", electionResetEvent_type, "chan bool")
+	}
+
+	// Check the value of `commitIndex`
+	if node.commitIndex != 0 {
+		t.Errorf("Invalid value %v for commitIndex, expected 0", node.commitIndex)
+	}
+
+	// Check the value of `lastApplied`
+	if node.lastApplied != 0 {
+		t.Errorf("Invalid value %v for lastApplied, expected 0", node.lastApplied)
+	}
+}

--- a/replicated_kv_store/states.go
+++ b/replicated_kv_store/states.go
@@ -273,7 +273,7 @@ func (node *RaftNode) StartElection() {
 
 						votes := int(atomic.AddInt32(&received_votes, 1))
 
-						if votes*2 > n_replica { // won the Election
+						if votes*2 > int(node.n_replicas) { // won the Election
 							node.ToLeader()
 							return
 						}


### PR DESCRIPTION
## Changes:
 
- `raft_node_test.go:` This is the file containing the tests for the functions in the file `raft_node.go`. As of now, it contains a single test case for the function `InitializeNode`.
 - `raft_node.go:` Add documentation for the members of the `RaftNode` struct.
 - `kv_store_node.go:` Add import for "testing" and add a workaround for a Golang testing issue in the `init()` function.
 - `states.go:` Fix a small issue where a global variable was being accessed. Ideally, the variable holding the same value in the
   `RaftNode` struct should be accessed.
 - `README.md:` Add instructions for writing new test cases and test files.